### PR TITLE
MacOS portability fixes

### DIFF
--- a/src/AFF4Containers.cc
+++ b/src/AFF4Containers.cc
@@ -27,6 +27,18 @@
 #include <Shlwapi.h>
 #endif
 
+#if defined(__APPLE__)
+
+// O_LARGEFILE is always on for macOS and thus not defined.
+#ifndef O_LARGEFILE
+#define O_LARGEFILE 0
+#endif
+
+// The following are equal on macOS
+#define pread64 pread
+
+#endif
+
 #include "AFF4Containers.h"
 #include "Zip.h"
 #include "AFF4ZipContainer.h"


### PR DESCRIPTION
While building this project using modern macOS tools (which included using 

```
autoreconf -i
```

as well as adding flags to find various libraries installed with Homebrew), I found one small change that can be made to the code to allow it to compile on macOS. (This is mostly lifted from another file.)